### PR TITLE
windows: use the known folders API

### DIFF
--- a/appdir_windows.go
+++ b/appdir_windows.go
@@ -3,24 +3,47 @@ package appdir
 import (
 	"os"
 	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/windows"
 )
 
 type dirs struct {
 	name string
 }
 
+var initOnce sync.Once
+var localAppData string
+var roamingAppData string
+
+func initFolders() {
+	var err error
+	localAppData, err = windows.KnownFolderPath(windows.FOLDERID_LocalAppData, 0)
+	if err != nil {
+		localAppData = os.Getenv("LOCALAPPDATA")
+	}
+	roamingAppData, err = windows.KnownFolderPath(windows.FOLDERID_RoamingAppData, 0)
+	if err != nil {
+		roamingAppData = os.Getenv("APPDATA")
+	}
+}
+
 func (d *dirs) UserConfig() string {
-	return filepath.Join(os.Getenv("APPDATA"), d.name)
+	initOnce.Do(initFolders)
+	return filepath.Join(roamingAppData, d.name)
 }
 
 func (d *dirs) UserCache() string {
-	return filepath.Join(os.Getenv("LOCALAPPDATA"), d.name)
+	initOnce.Do(initFolders)
+	return filepath.Join(localAppData, d.name)
 }
 
 func (d *dirs) UserLogs() string {
-	return filepath.Join(os.Getenv("LOCALAPPDATA"), d.name)
+	initOnce.Do(initFolders)
+	return filepath.Join(localAppData, d.name)
 }
 
 func (d *dirs) UserData() string {
-	return filepath.Join(os.Getenv("LOCALAPPDATA"), d.name)
+	initOnce.Do(initFolders)
+	return filepath.Join(localAppData, d.name)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/emersion/go-appdir
 
 go 1.15
+
+require golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f


### PR DESCRIPTION
On Windows, the actual path for the local and roaming AppData folders is
not guaranteed to be the same as its environment variable equivalent.
The environment variables are just default values.

The actual paths should be get with the Known Folders Windows API.

Fortunately the x/sys Go repository abstracts all the Win32 API calls so
that using the correct API is a small and simple change.

This won't change the output on Windows systems with standard paths.

Closes: #1